### PR TITLE
Add run-length encoding scheme to pixmap storage

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,7 +1,11 @@
 {
     "bg_color": "616db8",
-    "trident": {
-        "dimens": [212, 474],
-        "pixmap": "USB_icon_cropped.data"
-    }
+    "gfx": [
+        {
+            "name": "trident",
+            "dimens": [212, 474],
+            "pixmap": "USB_icon_cropped.data",
+            "type": 1
+        }
+    ]
 }

--- a/configure.py
+++ b/configure.py
@@ -40,7 +40,7 @@ def main():
         + str(int(path.getsize(config["trident"]["pixmap"]) / 4))
         + "\n"
     )
-    data_header.write("uint32_t pixmap[] = {\n")
+    data_header.write("uint32_t trident_pixmap[] = {\n")
     for block in iter(
         lambda: [
             pixmap.read(4),

--- a/configure.py
+++ b/configure.py
@@ -2,6 +2,9 @@
 
 import json as j
 from os import path
+from sys import stderr, exit
+
+imgtypes = [ "RAW", "RLE" ]
 
 
 def split_colors(color):
@@ -13,34 +16,29 @@ def split_colors(color):
     ]
 
 
-def main():
-    config = {}
-    with open(file="config.json", mode="r") as jfile:
-        config = j.load(jfile)
+def write_rledata(data_header, pixmap, img):
+    data_header.write("uint32_t " + img["name"] + "_rledata[] = {\n")
+    last_pixel = None
+    count = 0
+    for pixel in iter(lambda: pixmap.read(4), b""):
+        pixel = int.from_bytes(pixel, byteorder="big")
+        if pixel != last_pixel:
+            if last_pixel is not None:
+                data_header.write("0x{:08x},\n".format(count))
+            count = 1
+            data_header.write("  0x{:08x},".format(pixel))
+            last_pixel = pixel
+        elif pixel == last_pixel:
+            count += 1
+            if count == 0xffffffff:
+                data_header.write("0x{:08x},\n".format(count))
+                count = 0
+                pixel = None
+    data_header.write("0x{:08x},\n".format(count) + "};\n")
 
-    config["bg_color"] = split_colors(config["bg_color"])
-    print(config)
 
-    pixmap = open(file=config["trident"]["pixmap"], mode="rb")
-    data_header = open(file="img_data.h", mode="w")
-
-    data_header.write("#ifndef IMG_DATA_H\n#define IMG_DATA_H\n")
-    data_header.write("#define BG_R  " + config["bg_color"][0] + "\n")
-    data_header.write("#define BG_G  " + config["bg_color"][1] + "\n")
-    data_header.write("#define BG_B  " + config["bg_color"][2] + "\n")
-
-    data_header.write(
-        "#define PIXMAP_WIDTH  " + str(config["trident"]["dimens"][0]) + "\n"
-    )
-    data_header.write(
-        "#define PIXMAP_HEIGHT  " + str(config["trident"]["dimens"][1]) + "\n"
-    )
-    data_header.write(
-        "#define PIXMAP_PIXELS  "
-        + str(int(path.getsize(config["trident"]["pixmap"]) / 4))
-        + "\n"
-    )
-    data_header.write("uint32_t trident_pixmap[] = {\n")
+def write_rawdata(data_header, pixmap, img):
+    data_header.write("uint32_t " + img["name"] + "_rawdata[] = {\n")
     for block in iter(
         lambda: [
             pixmap.read(4),
@@ -56,6 +54,45 @@ def main():
             "  " + ",".join(map("0x{:08x}".format, block)) + ",\n"
         )
     data_header.write("};\n")
+
+
+def main():
+    config = {}
+    with open(file="config.json", mode="r") as jfile:
+        config = j.load(jfile)
+
+    config["bg_color"] = split_colors(config["bg_color"])
+    print(config)
+
+    data_header = open(file="img_data.h", mode="w")
+    data_header.write("#ifndef IMG_DATA_H\n#define IMG_DATA_H\n")
+    data_header.write("#include \"trident.h\"\n")
+    data_header.write("#define BG_R  " + config["bg_color"][0] + "\n")
+    data_header.write("#define BG_G  " + config["bg_color"][1] + "\n")
+    data_header.write("#define BG_B  " + config["bg_color"][2] + "\n")
+
+    for img in config["gfx"]:
+        pixmap = open(file=img["pixmap"], mode="rb")
+
+        if (img["type"] == 0):
+            write_rawdata(data_header, pixmap, img)
+            datavar = "  .data = " + img["name"] + "_rawdata\n"
+        elif (img["type"] == 1):
+            write_rledata(data_header, pixmap, img)
+            datavar = "  .data = " + img["name"] + "_rledata\n"
+        else:
+            print("ERROR: image data type not implemented!!", file=stderr)
+            pixmap.close()
+            data_header.close()
+
+        data_header.write(
+            "pixmap_t " + img["name"] + " = {\n"
+            + "  .width = " + str(img["dimens"][0]) + ",\n"
+            + "  .height = " + str(img["dimens"][1]) + ",\n"
+            + "  .n_pixels = " + str(int(path.getsize(img["pixmap"]) / 4)) + ",\n"
+            + "  .datatype = " + imgtypes[img["type"]] + ",\n"
+            + datavar + "};\n"
+        )
 
     data_header.write("#endif /* IMG_DATA_H */\n")
 

--- a/trident.c
+++ b/trident.c
@@ -2,7 +2,7 @@
  *  2023 Andrew "targetdisk" Rogers
  *
  *  Compile with:
- *    gcc -g -O0 -o fbtest fbtest.c
+ *    gcc -Wall -g -O0 -o trident trident.c
  */
 
 #include <fcntl.h>
@@ -10,32 +10,13 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <unistd.h>
 
 #include "img_data.h"
-
-typedef struct struct_fren {
-  int fb_fd;
-  struct fb_fix_screeninfo finfo;
-  struct fb_var_screeninfo vinfo;
-  long screensize;
-  uint8_t *fbp;
-} drawfren_t;
-
-#define GET_VINFO(fren) {                                  \
-  ioctl(fren->fb_fd, FBIOGET_VSCREENINFO, &fren->vinfo);   \
-}
-
-#define GET_FINFO(fren) {                                  \
-  ioctl(fren->fb_fd, FBIOGET_FSCREENINFO, &fren->finfo);   \
-}
-
-#define GET_INFOS(fren)  {  \
-  GET_VINFO(fren);          \
-  GET_FINFO(fren);          \
-}
+#include "trident.h"
 
 void setup_fren(drawfren_t *fren) {
   fren->fb_fd = open("/dev/fb0", O_RDWR);
@@ -75,23 +56,50 @@ static inline int bounded_rand(int lower, int upper) {
   return (rand() % (upper - lower + 1)) + lower;
 }
 
-void trident_test2(drawfren_t *df) {
-  long start_x = bounded_rand(0, df->vinfo.xres - PIXMAP_WIDTH);
+void draw_trident(drawfren_t *df, pixmap_t *pixmap) {
+  long start_x = bounded_rand(0, df->vinfo.xres - pixmap->width);
   long x = start_x;
-  long y = bounded_rand(0, df->vinfo.yres - PIXMAP_HEIGHT);
-  for (int pi = 0; pi < PIXMAP_PIXELS; pi++) {
-    if (pi % PIXMAP_WIDTH == 0) {
-      x = start_x;
-      y++;
-    } else {
-      x++;
+  long y = bounded_rand(0, df->vinfo.yres - pixmap->height);
+  {
+    uint32_t *data_ptr = pixmap->data;
+    for (size_t pi = 0; pi < pixmap->n_pixels; pi++) {
+      if (pi % pixmap->width == 0) {
+        x = start_x;
+        y++;
+      } else {
+        x++;
+      }
+      if (*data_ptr & 0x000000ff) {
+        *((uint32_t*)(df->fbp + pixel_location(x, y, df)))
+          = pixel_color((*data_ptr >> 24),
+            ((*data_ptr & 0x00ff0000) >> 16),
+            ((*data_ptr & 0x0000ff00) >> 8),
+            df);
+      }
+      data_ptr++;
     }
-    if (trident_pixmap[pi] & 0x000000ff) {
-      *((uint32_t*)(df->fbp + pixel_location(x, y, df)))
-        = pixel_color((trident_pixmap[pi] >> 24),
-          ((trident_pixmap[pi] & 0x00ff0000) >> 16),
-          ((trident_pixmap[pi] & 0x0000ff00) >> 8),
-          df);
+  }
+}
+
+void rle_decompress(pixmap_t *pixmap) {
+  switch (pixmap->datatype) {
+    case RAW:
+      return;
+    case RLE:
+      break;
+    default:
+      fprintf(stderr, "ERROR: image data type not implemented!!\n");
+      exit(1);
+  }
+  uint32_t *rledata = pixmap->data;
+  uint32_t *rawdata = malloc(sizeof(uint32_t) * pixmap->n_pixels);
+  pixmap->data = rawdata;
+  uint32_t *pixel;
+  for (size_t pi = 0; pi < pixmap->n_pixels; rledata++) {
+    pixel = rledata++;
+    printf("pixel = %#08x, repetitions = %#08x\n", *pixel, *rledata);
+    for (uint32_t pi_end = pi + *rledata; pi < pi_end; pi++) {
+      *rawdata++ = *pixel;
     }
   }
 }
@@ -105,10 +113,11 @@ int main(void) {
   drawfren_t fren;
   setup_fren(&fren);
   print_frenfo(&fren);
+  rle_decompress(&trident);
 
   for (int i = 0; i < 2048; i++) {
     fill_screen(pixel_color(BG_R, BG_G, BG_B, &fren), &fren);
-    trident_test2(&fren);
+    draw_trident(&fren, &trident);
     sleep(5);
   }
 

--- a/trident.c
+++ b/trident.c
@@ -86,11 +86,11 @@ void trident_test2(drawfren_t *df) {
     } else {
       x++;
     }
-    if (pixmap[pi] & 0x000000ff) {
+    if (trident_pixmap[pi] & 0x000000ff) {
       *((uint32_t*)(df->fbp + pixel_location(x, y, df)))
-        = pixel_color((pixmap[pi] >> 24),
-          ((pixmap[pi] & 0x00ff0000) >> 16),
-          ((pixmap[pi] & 0x0000ff00) >> 8),
+        = pixel_color((trident_pixmap[pi] >> 24),
+          ((trident_pixmap[pi] & 0x00ff0000) >> 16),
+          ((trident_pixmap[pi] & 0x0000ff00) >> 8),
           df);
     }
   }

--- a/trident.h
+++ b/trident.h
@@ -1,0 +1,36 @@
+#ifndef TRIDENT_H
+#define TRIDENT_H
+#include <stdint.h>
+#include <sys/ioctl.h>
+
+enum imgdata_type { RAW, RLE };
+
+typedef struct drawfren_s {
+  int fb_fd;
+  struct fb_fix_screeninfo finfo;
+  struct fb_var_screeninfo vinfo;
+  long screensize;
+  uint8_t *fbp;
+} drawfren_t;
+
+typedef struct pixmap_s {
+  int32_t width;
+  int32_t height;
+  size_t n_pixels;
+  char datatype;
+  uint32_t *data;
+} pixmap_t;
+
+#define GET_VINFO(fren) {                                  \
+  ioctl(fren->fb_fd, FBIOGET_VSCREENINFO, &fren->vinfo);   \
+}
+
+#define GET_FINFO(fren) {                                  \
+  ioctl(fren->fb_fd, FBIOGET_FSCREENINFO, &fren->finfo);   \
+}
+
+#define GET_INFOS(fren)  {  \
+  GET_VINFO(fren);          \
+  GET_FINFO(fren);          \
+}
+#endif /* TRIDENT_H */


### PR DESCRIPTION
Graphics are now compressed with a simple form of run-length encoding!
This means that our "trident" executable can now shrink from ~400KiB
down to ~35KiB!!  The savings are massive for the simple USB trident
pixmap!  Graphics stored in RLE format are now represented in chunks
consisting of two `uint32_t` values: RGBA pixel value and number of
repetitions.

Also in this commit are some changes to the configuration file JSON
format.  All pixmaps are to be stored in the "gfx" array as dictionaries
consisting of a name, dimensions [W,H], the source pixmap filename, and
an enumerated type (see trident.h:6).