### PR TITLE
1-bit RLE format for flat-colored graphics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ img_data.h
 crud
 tags
 README.html
+dist
+
+*.swo
+*.swn
+*.swp

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
-UNAME=$(shell uname)
+UNAME = $(shell uname)
+STRIP ?= strip
 
-CFLAGS=-Wall
+CFLAGS ?= -Wall
 ifeq ($(UNAME),Linux)
 	OPEN=xdg-open
 endif
@@ -12,8 +13,11 @@ README: pub-css # Requires Pandoc to be installed
 	pandoc README.md -s -c pub.css -o README.html
 	$(OPEN) README.html
 
-trident:
-	$(CC) $(CFLAGS) -m32 trident.c -o trident
+trident: trident.c
+	$(CC) $(CFLAGS) -m32 -o $@ $<
+
+strip: trident
+	$(STRIP) $^
 
 clean:
 	rm trident

--- a/config.json
+++ b/config.json
@@ -5,7 +5,8 @@
             "name": "trident",
             "dimens": [212, 474],
             "pixmap": "USB_icon_cropped.data",
-            "type": 1
+            "fgcolor": "ffe400",
+            "type": 2
         }
     ]
 }

--- a/configure.py
+++ b/configure.py
@@ -4,7 +4,7 @@ import json as j
 from os import path
 from sys import stderr, exit
 
-imgtypes = [ "RAW", "RLE" ]
+imgtypes = ["RAW", "RLE", "RLE1"]
 
 
 def split_colors(color):
@@ -14,6 +14,38 @@ def split_colors(color):
         hex((numcolor & 0x00FF00) >> 8),
         hex(numcolor & 0x0000FF),
     ]
+
+
+def write_rle1data(data_header, pixmap, img):
+    last_pixel = None
+    count = 0
+    packed = [0, 0]
+
+    def pack(byte, packed):
+        packed[0] = packed[0] << 8
+        packed[0] += byte
+        packed[1] += 1
+        if packed[1] == 4:
+            data_header.write("  0b{:032b},\n".format(packed[0]))
+            packed = [0, 0]
+        return packed
+
+    for pixel in iter(lambda: pixmap.read(4), b""):
+        pixel = int.from_bytes(pixel, byteorder="big") & 1
+        if pixel != last_pixel:
+            if last_pixel is not None:
+                packed = pack((last_pixel << 7) + count, packed)
+            count = 1
+            last_pixel = pixel
+        elif pixel == last_pixel:
+            count += 1
+            if count == 127:
+                packed = pack((last_pixel << 7) + count, packed)
+                count = 0
+                last_pixel = None
+    packed = pack((last_pixel << 7) + count, packed)
+    while packed[1]:
+        packed = pack(0, packed)
 
 
 def write_rledata(data_header, pixmap, img):
@@ -30,10 +62,10 @@ def write_rledata(data_header, pixmap, img):
             last_pixel = pixel
         elif pixel == last_pixel:
             count += 1
-            if count == 0xffffffff:
+            if count == 0xFFFFFFFF:
                 data_header.write("0x{:08x},\n".format(count))
                 count = 0
-                pixel = None
+                last_pixel = None
     data_header.write("0x{:08x},\n".format(count) + "};\n")
 
 
@@ -66,7 +98,7 @@ def main():
 
     data_header = open(file="img_data.h", mode="w")
     data_header.write("#ifndef IMG_DATA_H\n#define IMG_DATA_H\n")
-    data_header.write("#include \"trident.h\"\n")
+    data_header.write('#include "trident.h"\n')
     data_header.write("#define BG_R  " + config["bg_color"][0] + "\n")
     data_header.write("#define BG_G  " + config["bg_color"][1] + "\n")
     data_header.write("#define BG_B  " + config["bg_color"][2] + "\n")
@@ -74,24 +106,46 @@ def main():
     for img in config["gfx"]:
         pixmap = open(file=img["pixmap"], mode="rb")
 
-        if (img["type"] == 0):
+        if img["type"] == 0:
             write_rawdata(data_header, pixmap, img)
             datavar = "  .data = " + img["name"] + "_rawdata\n"
-        elif (img["type"] == 1):
+        elif img["type"] == 1:
             write_rledata(data_header, pixmap, img)
             datavar = "  .data = " + img["name"] + "_rledata\n"
+        elif img["type"] == 2:
+            data_header.write(
+                "uint32_t "
+                + img["name"]
+                + "_rle1data[] = {\n  0x"
+                + img["fgcolor"]
+                + "ff,\n"
+            )
+            write_rle1data(data_header, pixmap, img)
+            data_header.write("};\n")
+            datavar = "  .data = " + img["name"] + "_rle1data\n"
         else:
             print("ERROR: image data type not implemented!!", file=stderr)
             pixmap.close()
             data_header.close()
 
         data_header.write(
-            "pixmap_t " + img["name"] + " = {\n"
-            + "  .width = " + str(img["dimens"][0]) + ",\n"
-            + "  .height = " + str(img["dimens"][1]) + ",\n"
-            + "  .n_pixels = " + str(int(path.getsize(img["pixmap"]) / 4)) + ",\n"
-            + "  .datatype = " + imgtypes[img["type"]] + ",\n"
-            + datavar + "};\n"
+            "pixmap_t "
+            + img["name"]
+            + " = {\n"
+            + "  .width = "
+            + str(img["dimens"][0])
+            + ",\n"
+            + "  .height = "
+            + str(img["dimens"][1])
+            + ",\n"
+            + "  .n_pixels = "
+            + str(int(path.getsize(img["pixmap"]) / 4))
+            + ",\n"
+            + "  .datatype = "
+            + imgtypes[img["type"]]
+            + ",\n"
+            + datavar
+            + "};\n"
         )
 
     data_header.write("#endif /* IMG_DATA_H */\n")

--- a/trident.h
+++ b/trident.h
@@ -3,7 +3,7 @@
 #include <stdint.h>
 #include <sys/ioctl.h>
 
-enum imgdata_type { RAW, RLE };
+enum imgdata_type { RAW, RLE, RLE1 };
 
 typedef struct drawfren_s {
   int fb_fd;


### PR DESCRIPTION
Add new 1-bit RLE format for flat-colored graphics

This commit adds a new format consisting of a `uint32_t` array
containing 1-4 runs of 1-bit pixel values, prepended with a foreground
color.  To account for this, `config.json` files using "type 2" graphics
will also need an 24-bit RGB `fgcolor` value.

It looks something like this:
```
  {
    0xffe400ff,  /* 32-bit RGBA foreground color */
    0       1101001     1    0000010  0   1111111  0   1010010,
    ↑          ↑        ↑    ↑        ↑    ↑       ↑   ↑
    1-bit  repetitions  1BV  reps.    1BV  reps.  1BV  reps.
    value

    ...

    001111111001001001100001   00000000,
               ↑                 ↑
        Final RLE Run(s)       1-3 bytes of padding
  }
```

Because all the stuffed values must take the form of uint32_t values,
1-3 bytes of padding may need to be added to the end of the data when
creating a compiled-in RLE data structure.